### PR TITLE
Let UUID peek through in the environment.

### DIFF
--- a/service/runs.go
+++ b/service/runs.go
@@ -130,6 +130,8 @@ func (l *RunList) execute(r *Run) {
 		shell, commandArg := getShell()
 		cmd := exec.Command(shell, commandArg, task.Script)
 
+		cmd.Env = append(cmd.Env, "UUID=" + r.UUID)
+
 		outPipe, err := cmd.StdoutPipe()
 		if err != nil {
 			reportRunError(l, r, result, err)


### PR DESCRIPTION
This is helpful in build environments, so you can reference the
same build directory in different tasks for the same job.
